### PR TITLE
#162046982 Toggle travel readiness for outflow and inflow on a specific center

### DIFF
--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -99,6 +99,8 @@ export const deleteChecklistItem = [
     'Reason for deletion is required')
     .trim().isLength({ min: 3, }),
 ];
+
+// type can be file or json
 export const travelReadinessValidators = [
   query('page', 'Page must be a positive integer')
     .isInt({ gt: 0 })
@@ -107,5 +109,7 @@ export const travelReadinessValidators = [
     .isInt({ gt: 0 })
     .optional(),
   query('type', 'Type must be a string')
-    .isString('')
+    .isString(''),
+  query('travelFlow', 'Travel flow should either be inflow or outflow')
+    .isIn(['inflow', 'outflow'])
 ];

--- a/src/modules/analytics/travelReadiness/__tests__/readiness.test.js
+++ b/src/modules/analytics/travelReadiness/__tests__/readiness.test.js
@@ -29,10 +29,21 @@ const adminUser = {
     id: '-HyfghjTUGfghjkIJM',
     fullName: 'Miguna Miguna',
     email: 'travel.admin@andela.com',
-    name: 'Travel Admin',
+    passportName: 'Travel Admin',
+    location: 'Lagos',
     picture: ''
   },
 };
+
+const andelacenter = [{
+  id: 12345,
+  location: 'Lagos, Nigeria'
+},
+{
+  id: 23456,
+  location: 'Nairobi, Kenya'
+}];
+
 const userToken = Utils.generateTestToken(normalUser);
 const adminToken = Utils.generateTestToken(adminUser);
 describe('Test Suite for Trips Analytics => Get Travel Readiness of requesters)', () => {
@@ -42,6 +53,7 @@ describe('Test Suite for Trips Analytics => Get Travel Readiness of requesters)'
     await models.Bed.destroy({ truncate: true, cascade: true });
     await models.Role.destroy({ truncate: true, cascade: true });
     await models.User.destroy({ truncate: true, cascade: true });
+    await models.Center.destroy({ truncate: true, cascade: true });
     await models.UserRole.destroy({ truncate: true, cascade: true });
     await models.Request.destroy({ truncate: true, cascade: true });
     await models.Trip.destroy({ truncate: true, cascade: true });
@@ -49,6 +61,7 @@ describe('Test Suite for Trips Analytics => Get Travel Readiness of requesters)'
     await models.User.create(travelAdmin);
     await models.User.create(travelRequester);
     await models.UserRole.create(userRole);
+    await models.Center.bulkCreate(andelacenter);
     request(app)
       .post('/api/v1/guesthouses')
       .set('Content-Type', 'application/json')
@@ -69,6 +82,7 @@ describe('Test Suite for Trips Analytics => Get Travel Readiness of requesters)'
     await models.Role.destroy({ truncate: true, cascade: true });
     await models.User.destroy({ truncate: true, cascade: true });
     await models.UserRole.destroy({ truncate: true, cascade: true });
+    await models.Center.destroy({ truncate: true, cascade: true });
     await models.Request.destroy({ truncate: true, cascade: true });
     await models.Trip.destroy({ truncate: true, cascade: true });
   });
@@ -86,7 +100,7 @@ describe('Test Suite for Trips Analytics => Get Travel Readiness of requesters)'
   });
   it('should require user to be a travel Admin', (done) => {
     request(app)
-      .get('/api/v1/analytics/readiness?page=1&limit=3&type=json')
+      .get('/api/v1/analytics/readiness?page=1&limit=3&type=json&travelFlow=inflow')
       .set('Content-Type', 'application/json')
       .set('authorization', userToken)
       .end((err, res) => {
@@ -99,7 +113,7 @@ describe('Test Suite for Trips Analytics => Get Travel Readiness of requesters)'
   });
   it('should return 200 status, travel readiness and pagination data', (done) => {
     request(app)
-      .get('/api/v1/analytics/readiness?page=1&limit=3&type=json')
+      .get('/api/v1/analytics/readiness?page=1&limit=3&type=json&travelFlow=inflow')
       .set('Content-Type', 'application/json')
       .set('authorization', adminToken)
       .end((err, res) => {
@@ -112,7 +126,7 @@ describe('Test Suite for Trips Analytics => Get Travel Readiness of requesters)'
   });
   it('should return csv data when type is set to file', (done) => {
     request(app)
-      .get('/api/v1/analytics/readiness?page=1&limit=3&type=file')
+      .get('/api/v1/analytics/readiness?page=1&limit=3&type=file&travelFlow=inflow')
       .set('Content-Type', 'application/json')
       .set('authorization', adminToken)
       .end((err, res) => {


### PR DESCRIPTION
#### What does this PR do?
-Enable Travel admin should view travel readiness of potential travelers to their center and out of their centers

#### Description of Task to be completed?
-Modify the endpoint that retrieves travel readiness of potential travelers to allow for both inflow and outflow
- Validate to make sure that in travel flow only values accepted is outflow and inflow

#### How should this be manually tested?

- Clone the repo - `git clone https://github.com/andela/travel_tool_back.git`
- Enter into the project directory - `cd travel_tool_back`
- Checkout the branch `git checkout ft-toggle-travel-readiness-card-162046982`
- Install dependencies - `yarn install`
- Start the server - `make start`
- Navigate to travela in your browser and log in
- Login on your browser and grab your token from the application tab in Developers tab
- Open Postman and Add your token in the headers
- Nagivate to your database GUI (pgAdmin or postico)
- Update your user role in UserRoles table to 'Travel Administrator' 29187
- Make a get request to `http://localhost:5000/api/v1/analytics/readiness?page=1&limit=5&type=json&travelFlow=inflow` to retrieve `json` format of the response of inflow. To make response of outflow, change query of travelFlow=outflow. 
- Make a get request to `http://localhost:5000/api/v1/analytics/readiness?page=1&limit=5&type=file&travelFlow=inflow` to retrieve `csv` file of the response.

#### Any background context you want to provide?
- You need to assign yourself the role of Travel Admin or SuperAdmin to test this endpoint
- Only inflow and outflow are used as queries for travelFlow

#### What are the relevant pivotal tracker stories?
[Delivers 162046982](https://www.pivotaltracker.com/story/show/162046982)

#### Screenshots (if appropriate)
`JSON format`

<img width="1224" alt="screen shot 2018-11-20 at 12 20 00" src="https://user-images.githubusercontent.com/32410518/48763618-ba662d80-ecbe-11e8-97b0-04ff3c13c916.png">

`CSV  format`

<img width="1116" alt="screen shot 2018-11-20 at 12 20 12" src="https://user-images.githubusercontent.com/32410518/48763637-c3ef9580-ecbe-11e8-8926-ca6f5f801c89.png">

#### Questions:
None
