### PR TITLE
#161051781 User can delete a request with 'open' status

### DIFF
--- a/src/database/migrations/20181120130105-add-delete-column-request.js
+++ b/src/database/migrations/20181120130105-add-delete-column-request.js
@@ -1,0 +1,10 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'Requests', 'deletedAt',
+    {
+      allowNull: true,
+      type: Sequelize.DATE
+    }
+  ),
+  down: queryInterface => queryInterface.removeColumn('Requests', 'deletedAt')
+};

--- a/src/database/migrations/20181121034325-delete-trips.js.js
+++ b/src/database/migrations/20181121034325-delete-trips.js.js
@@ -1,0 +1,10 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'Trips', 'deletedAt',
+    {
+      allowNull: true,
+      type: Sequelize.DATE
+    }
+  ),
+  down: queryInterface => queryInterface.removeColumn('Trips', 'deletedAt')
+};

--- a/src/database/migrations/20181122090543-add-delete-column-approval.js
+++ b/src/database/migrations/20181122090543-add-delete-column-approval.js
@@ -1,0 +1,10 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'Approvals', 'deletedAt',
+    {
+      allowNull: true,
+      type: Sequelize.DATE
+    }
+  ),
+  down: queryInterface => queryInterface.removeColumn('Approvals', 'deletedAt')
+};

--- a/src/database/models/Approval.js
+++ b/src/database/models/Approval.js
@@ -30,7 +30,7 @@ export default (sequelize, DataTypes) => {
       allowNull: false,
       type: DataTypes.DATE,
     }
-  });
+  }, { paranoid: true });
   Approval.associate = (models) => {
     Approval.belongsTo(models.Request, {
       foreignKey: 'requestId',

--- a/src/database/models/request.js
+++ b/src/database/models/request.js
@@ -88,7 +88,7 @@ export default (sequelize, DataTypes) => {
         },
       },
     },
-  });
+  }, { paranoid: true });
 
   Request.associate = (models) => {
     Request.hasMany(models.Comment, {

--- a/src/database/models/trip.js
+++ b/src/database/models/trip.js
@@ -60,7 +60,7 @@ export default (sequelize, DataTypes) => {
       defaultValue: 'false',
       type: DataTypes.ENUM('true', 'false')
     }
-  });
+  }, { paranoid: true });
   Trip.associate = (models) => {
     Trip.belongsTo(models.Bed, {
       allowNull: true,

--- a/src/helpers/email/mailTemplate.js
+++ b/src/helpers/email/mailTemplate.js
@@ -4,6 +4,26 @@ import switchButtonText from './switchButtonText';
 
 dotenv.config();
 
+const returnButton = (type, redirectLink) => {
+  const button = type !== 'Deleted Request' ? `<a
+  href="${redirectLink}"
+  class="button"
+  style="width: 174px;
+    border-radius: 4px;
+    background-color: #3359DB;
+    text-decoration: none;
+    color: white;
+    font-family: Helvetica; font-size: 17px;
+    line-height: 20px; text-align: center;
+    display: block; padding: 13px 0;
+    margin: 0 auto 73px auto;
+    margin-bottom: 73px;"
+>
+  ${switchButtonText(type)}
+</a>` : '';
+  return button;
+};
+
 const mailTemplate = (
   recipientName,
   senderName,
@@ -63,22 +83,7 @@ const mailTemplate = (
     type, senderName, recipientName, requestId, comment
   })}
     </p>
-    <a
-      href="${redirectLink}"
-      class="button"
-      style="width: 174px;
-        border-radius: 4px;
-        background-color: #3359DB;
-        text-decoration: none;
-        color: white;
-        font-family: Helvetica; font-size: 17px;
-        line-height: 20px; text-align: center;
-        display: block; padding: 13px 0;
-        margin: 0 auto 73px auto;
-        margin-bottom: 73px;"
-    >
-      ${switchButtonText(type)}
-    </a>
+    ${returnButton(type, redirectLink)}
   </div>
   <div
     style="box-sizing: border-box;

--- a/src/helpers/email/switchButtonText.js
+++ b/src/helpers/email/switchButtonText.js
@@ -4,6 +4,8 @@ const switchButtonText = (type) => {
       return 'View Request';
     case 'Trip Survey':
       return 'Fill Survey';
+    case 'Deleted Request':
+      return 'View Notification';
     default:
       return 'View Request';
   }

--- a/src/helpers/email/switchMessage.js
+++ b/src/helpers/email/switchMessage.js
@@ -14,11 +14,7 @@ const attachCommentToMail = msgDetail => (
           <tbody >
             <tr >
             <td width="20%" ><img src=${msgDetail.comment.dataValues.picture} 
-            style="
-            border-radius: 50%;
-            width: 50px;
-            height: 50px;
-              "
+            style="border-radius: 50%; width: 50px; height: 50px;"
             /></td>
             <td width="80%"> 
               <i>${msgDetail.comment.dataValues.comment}</i></td>
@@ -27,6 +23,16 @@ const attachCommentToMail = msgDetail => (
             </table>
   `
 );
+
+const deleteMessage = msgDetail => `The travel request\
+<b> #${msgDetail.requestId}</b> was just deleted
+  by ${msgDetail.senderName}. Login to your travela account for details.`;
+
+const updateMessage = msgDetail => (
+  `<b style="text-transform: capitalize;\
+  ">${msgDetail.senderName}</b> just updated a travel request for your approval. Login to your
+  travela account for details.`);
+
 const switchMessage = (msgDetail) => {
   switch (msgDetail.type) {
     case 'New Request':
@@ -44,10 +50,10 @@ const switchMessage = (msgDetail) => {
       return (
         attachCommentToMail(msgDetail)
       );
+    case 'Deleted Request':
+      return deleteMessage(msgDetail);
     case 'Updated Request':
-      return (
-        `<b style="text-transform: capitalize;">${msgDetail.senderName}</b> just updated a travel request for your approval. Login to your
-        travela account for details.`);
+      return updateMessage(msgDetail);
     case 'Changed Room':
       return (
         `Your residence record for the travel request 

--- a/src/modules/requests/__tests__/mocks/mockData.js
+++ b/src/modules/requests/__tests__/mocks/mockData.js
@@ -269,6 +269,9 @@ export const generateMockData = (mailType) => {
   } else if (mailType === 'Updated Request') {
     message = 'edited a travel request';
     mailTopic = 'Updated Travel Request';
+  } else if (mailType === 'Deleted Request') {
+    message = 'deleted a travel request';
+    mailTopic = 'Deleted Travel Request';
   }
 
   return {

--- a/src/modules/requests/index.js
+++ b/src/modules/requests/index.js
@@ -42,4 +42,11 @@ RequestsRouter.put(
   RequestsController.updateRequest,
 );
 
+RequestsRouter.delete(
+  '/requests/:requestId',
+  authenticate,
+  Validator.validateRequest,
+  RequestsController.deleteRequest,
+);
+
 export default RequestsRouter;


### PR DESCRIPTION
#### What does this PR do?
This PR enables a requester to delete a request, their manager is then notified about the action carried out.

#### Description of Task to be completed?
-Travel requester should be able to delete only open requests
- The request should be deleted from Manager's approval page
- The manager should get an in-app notification to this effect

#### How should this be manually tested?
- Clone the repo - `git clone https://github.com/andela/travel_tool_back.git`
- Enter into the project directory - `cd travel_tool_back`
- checkout the branch `ft-delete-requests-161051781`
- Start the server - `make start`
- Navigate to [travela](http://travela-local.andela.com:3000/#) in your browser and log in
- Login on your browser and grab your token from the application tab in Developers tab
- Open Postman
- Add your token in headers
- Navigate to your database GUI (pgAdmin or postico)
- Update your user role in UserRoles table to 'Travel Administrator' `29187`
- Post a request as shown [here](https://github.com/andela/travel_tool_back/pull/44)
- Delete the request using `http://127.0.0.1:5000/api/v1/requests/requestId`

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?
[161051781](https://www.pivotaltracker.com/story/show/161051781)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30747298/48782940-4fcde580-ecf0-11e8-9c8b-f5d53688af9b.png)

#### Questions:
