### PR TITLE
#162152454 Update or delete maintenance records

### DIFF
--- a/src/database/migrations/20181123061939-add-delete-column-maintainance.js
+++ b/src/database/migrations/20181123061939-add-delete-column-maintainance.js
@@ -1,0 +1,10 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'Maintainances', 'deletedAt',
+    {
+      allowNull: true,
+      type: Sequelize.DATE
+    }
+  ),
+  down: queryInterface => queryInterface.removeColumn('Maintainances', 'deletedAt')
+};

--- a/src/database/models/maintainance.js
+++ b/src/database/models/maintainance.js
@@ -11,7 +11,7 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       type: DataTypes.DATEONLY,
     },
-  });
+  }, { paranoid: true });
   Maintainance.associate = (models) => {
     Maintainance.belongsTo(models.Room, {
       foreignKey: 'roomId',

--- a/src/middlewares/__mocks__/index.js
+++ b/src/middlewares/__mocks__/index.js
@@ -101,6 +101,10 @@ const middleware = {
     validateSubmission: jest.fn(invokeNextMiddleware),
     validateTrip: jest.fn(invokeNextMiddleware),
     getChecklistItem: jest.fn(invokeNextMiddleware),
+  },
+  guestHouseValidator: {
+    checkRoom: jest.fn(invokeNextMiddleware),
+    checkMaintenanceRecord: jest.fn(invokeNextMiddleware)
   }
 };
 

--- a/src/middlewares/guestHouseValidator.js
+++ b/src/middlewares/guestHouseValidator.js
@@ -1,0 +1,35 @@
+import models from '../database/models';
+
+class GuestHouseValidator {
+  static async checkRoom(req, res, next) {
+    const room = await models.Room.findOne({
+      where: {
+        id: req.params.id
+      }
+    });
+    if (!room) {
+      return res.status(404).send({
+        success: false,
+        message: 'The room does not exist'
+      });
+    }
+    next();
+  }
+
+  static async checkMaintenanceRecord(req, res, next) {
+    const maintenanceRecord = await models.Maintainance.findOne({
+      where: {
+        roomId: req.params.id
+      }
+    });
+    if (!maintenanceRecord) {
+      return res.status(404).json({
+        success: false,
+        message: 'The maintenance record does not exist'
+      });
+    }
+    next();
+  }
+}
+
+export default GuestHouseValidator;

--- a/src/modules/guestHouse/GuestHouseController.js
+++ b/src/modules/guestHouse/GuestHouseController.js
@@ -47,28 +47,59 @@ class GuestHouseController {
   }
 
   static async createMaintainanceRecord(req, res) {
-    const roomId = req.params.id;
-    const room = await models.Room.findOne({
-      where: {
-        id: req.params.id
-      }
-    });
-    if (!room) {
-      return res.status(400).json({
-        success: false,
-        message: 'The room does not exist'
+    try {
+      const newMaintainanceRecord = await models.Maintainance.create({
+        ...req.body,
+        roomId: req.params.id
       });
+      return res.status(201).json({
+        success: true,
+        message: 'Room maintainance record created',
+        maintainance: newMaintainanceRecord,
+      });
+    } catch (error) { /* istanbul ignore next */
+      Error.handleError(error, 500, res);
     }
-    const maintainanceData = {
-      ...req.body,
-      roomId
-    };
-    const newMaintainanceRecord = await models.Maintainance.create(maintainanceData);
-    return res.status(201).json({
-      success: true,
-      message: 'Room maintainance record created',
-      maintainance: newMaintainanceRecord,
-    });
+  }
+
+  static async updateMaintenanceRecord(req, res) {
+    try {
+      const updatedMaintenanceRecord = await models.Maintainance
+        .update({ ...req.body }, {
+          returning: true,
+          where: {
+            roomId: req.params.id
+          }
+        });
+      return updatedMaintenanceRecord[0] === 0
+        ? res.status(404).json({
+          success: false,
+          message: 'The maintenance record does not exist'
+        })
+        : res.status(200).json({
+          success: true,
+          message: 'Room maintenance record updated',
+          maintenance: updatedMaintenanceRecord
+        });
+    } catch (error) { /* istanbul ignore next */
+      Error.handleError(error, 500, res);
+    }
+  }
+
+  static async deleteMaintenanceRecord(req, res) {
+    try {
+      await models.Maintainance.destroy({
+        where: {
+          roomId: req.params.id
+        }
+      });
+      return res.status(200).json({
+        success: true,
+        message: 'Maintenance record deleted successfully'
+      });
+    } catch (error) { /* istanbul ignore next */
+      Error.handleError(error, 500, res);
+    }
   }
 
   static async updateRoomFaultyStatus(req, res) {

--- a/src/modules/guestHouse/__tests__/deleteMaintenance.test.js
+++ b/src/modules/guestHouse/__tests__/deleteMaintenance.test.js
@@ -1,0 +1,150 @@
+import request from 'supertest';
+import app from '../../../app';
+import Utils from '../../../helpers/Utils';
+import models from '../../../database/models';
+import { role } from '../../userRole/__tests__/mocks/mockData';
+
+import {
+  GuestHouseEpic,
+  GuestHouseEpicRoom,
+  GuestHouseEpicRoom2,
+  GuestHouseEpicBed,
+  maintainanceRecord,
+} from './mocks/guestHouseData';
+
+const userMock = [
+  {
+    id: 40001,
+    fullName: 'Ghost roommate',
+    email: 'ghost.roommate@andela.com',
+    userId: '-MUnaemKrxA90lPhjkkllFOLNm',
+    location: 'Lagos',
+    createdAt: '2018-08-16 012:11:52.181+01',
+    updatedAt: '2018-08-16 012:11:52.181+01'
+  },
+  {
+    id: 40002,
+    fullName: 'Ronald Ndirangu',
+    email: 'ronald.ndirangu@andela.com',
+    userId: '-MUnaemKrxA90lPNQs1FOLNm',
+    location: 'Nairobi',
+    createdAt: '2018-08-16 012:11:52.181+01',
+    updatedAt: '2018-08-16 012:11:52.181+01'
+  }
+];
+
+const userRoleMock = [
+  {
+    id: 1,
+    userId: 40002,
+    roleId: 29187,
+    createdAt: '2018-08-16 012:11:52.181+01',
+    updatedAt: '2018-08-16 012:11:52.181+01'
+  },
+  {
+    id: 2,
+    userId: 40001,
+    roleId: 401938,
+    createdAt: '2018-08-16 012:11:52.181+01',
+    updatedAt: '2018-08-16 012:11:52.181+01'
+  }
+];
+const travelAdminPayload = {
+  UserInfo: {
+    id: '-MUnaemKrxA90lPNQs1FOLNm',
+    fullName: 'Ronald Ndirangu',
+    email: 'ronald.ndirangu@andela.com',
+    picture: 'fakePicture.png'
+  },
+};
+const requesterPayload = {
+  UserInfo: {
+    userId: '-MUnaemKrxA90lPhjkkllFOLNm',
+    fullName: 'Ghost roommate',
+    email: 'ghost.roommate@andela.com',
+    picture: 'fakePicture.png'
+  }
+};
+
+const travelAdminToken = Utils.generateTestToken(travelAdminPayload);
+const requesterToken = Utils.generateTestToken(requesterPayload);
+
+describe('Update maintenance record', () => {
+  beforeAll(async (done) => {
+    await models.Bed.destroy({ truncate: true, cascade: true });
+    await models.Room.destroy({ truncate: true, cascade: true });
+    await models.GuestHouse.destroy({ truncate: true, cascade: true });
+    await models.User.destroy({ truncate: true, cascade: true });
+    await models.Role.destroy({ truncate: true, cascade: true });
+    await models.UserRole.destroy({ truncate: true, cascade: true });
+
+    await models.Role.bulkCreate(role);
+    await models.User.bulkCreate(userMock);
+    await models.UserRole.bulkCreate(userRoleMock);
+    await models.GuestHouse.create({ ...GuestHouseEpic, userId: '-MUnaemKrxA90lPNQs1FOLNm' });
+    await models.Room.create(GuestHouseEpicRoom);
+    await models.Room.create(GuestHouseEpicRoom2);
+    await models.Bed.bulkCreate(GuestHouseEpicBed);
+    await models.Maintainance.create({ ...maintainanceRecord, roomId: 'bEu6thdW' });
+
+    request(app)
+      .post('/api/v1/room/bEu6thdW/maintainance')
+      .set('authorization', travelAdminToken)
+      .send(maintainanceRecord)
+      .expect(201)
+      .end((err, res) => {
+        expect(res.body.success).toEqual(true);
+        expect(res.body.message).toBe('Room maintainance record created');
+        if (err) return done(err);
+        done();
+      });
+  });
+
+  afterAll(async () => {
+    await models.Role.destroy({ force: true, truncate: { cascade: true } });
+    await models.User.destroy({ force: true, truncate: { cascade: true } });
+    await models.UserRole.destroy({ force: true, truncate: { cascade: true } });
+    await models.Bed.destroy({ truncate: true, cascade: true });
+    await models.Room.destroy({ truncate: true, cascade: true });
+    await models.GuestHouse.destroy({ truncate: true, cascade: true });
+    await models.Maintainance.destroy({ truncate: true, cascade: true });
+  });
+
+  it('should return an error if record doesn\'t exist', (done) => {
+    request(app)
+      .delete('/api/v1/room/cYu7hypT/maintainance')
+      .set('authorization', travelAdminToken)
+      .expect(404)
+      .end((err, res) => {
+        expect(res.body.message).toBe('The maintenance record does not exist');
+        if (err) return err;
+        done();
+      });
+  });
+
+  it('should delete record successfully if room exist and user is travel admin', (done) => {
+    request(app)
+      .delete('/api/v1/room/bEu6thdW/maintainance')
+      .set('authorization', travelAdminToken)
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.message).toBe('Maintenance record deleted successfully');
+        if (err) return err;
+        done();
+      });
+  });
+
+  it('should throw 403 error if room exist and user is not a travel admin', (done) => {
+    request(app)
+      .delete('/api/v1/room/bEu6thdW/maintainance')
+      .set('authorization', requesterToken)
+      .expect(403)
+      .end((err, res) => {
+        expect(res.body.success).toEqual(false);
+        expect(res.body.error)
+          .toBe('You don\'t have access to perform this action');
+        if (err) return err;
+        done();
+      });
+  });
+});

--- a/src/modules/guestHouse/__tests__/mocks/guestHouseData.js
+++ b/src/modules/guestHouse/__tests__/mocks/guestHouseData.js
@@ -149,6 +149,17 @@ export const GuestHouseEpicRoom = {
   updatedAt: '2018-09-26T15:47:47.576Z',
 };
 
+export const GuestHouseEpicRoom2 = {
+  id: 'cYu7hypT',
+  roomName: 'big cutter 2',
+  roomType: 'ensuited',
+  bedCount: '2',
+  faulty: false,
+  guestHouseId: 'ND56thdW',
+  createdAt: '2018-09-26T15:47:47.576Z',
+  updatedAt: '2018-09-26T15:47:47.576Z',
+};
+
 export const GuestHouseEpicBed = [
   {
     id: 18,

--- a/src/modules/guestHouse/__tests__/updateMaintenance.test.js
+++ b/src/modules/guestHouse/__tests__/updateMaintenance.test.js
@@ -1,0 +1,172 @@
+import request from 'supertest';
+import app from '../../../app';
+import Utils from '../../../helpers/Utils';
+import models from '../../../database/models';
+import { role } from '../../userRole/__tests__/mocks/mockData';
+
+import {
+  GuestHouseEpic,
+  GuestHouseEpicRoom,
+  GuestHouseEpicBed,
+  maintainanceRecord,
+  GuestHouseEpicRoom2,
+} from './mocks/guestHouseData';
+
+const userMock = [
+  {
+    id: 40001,
+    fullName: 'Ghost roommate',
+    email: 'ghost.roommate@andela.com',
+    userId: '-MUnaemKrxA90lPhjkkllFOLNm',
+    location: 'Lagos',
+    createdAt: '2018-08-16 012:11:52.181+01',
+    updatedAt: '2018-08-16 012:11:52.181+01'
+  },
+  {
+    id: 40002,
+    fullName: 'Ronald Ndirangu',
+    email: 'ronald.ndirangu@andela.com',
+    userId: '-MUnaemKrxA90lPNQs1FOLNm',
+    location: 'Nairobi',
+    createdAt: '2018-08-16 012:11:52.181+01',
+    updatedAt: '2018-08-16 012:11:52.181+01'
+  }
+];
+
+const userRoleMock = [
+  {
+    id: 1,
+    userId: 40002,
+    roleId: 29187,
+    createdAt: '2018-08-16 012:11:52.181+01',
+    updatedAt: '2018-08-16 012:11:52.181+01'
+  },
+  {
+    id: 2,
+    userId: 40001,
+    roleId: 401938,
+    createdAt: '2018-08-16 012:11:52.181+01',
+    updatedAt: '2018-08-16 012:11:52.181+01'
+  }
+];
+const travelAdminPayload = {
+  UserInfo: {
+    id: '-MUnaemKrxA90lPNQs1FOLNm',
+    fullName: 'Ronald Ndirangu',
+    email: 'ronald.ndirangu@andela.com',
+    picture: 'fakePicture.png'
+  },
+};
+const requesterPayload = {
+  UserInfo: {
+    userId: '-MUnaemKrxA90lPhjkkllFOLNm',
+    fullName: 'Ghost roommate',
+    email: 'ghost.roommate@andela.com',
+    picture: 'fakePicture.png'
+  }
+};
+
+const updateMaintainanceRecord = {
+  reason: 'Leaking pipes',
+  start: '11/02/2018',
+  end: '11/21/2018'
+};
+
+const travelAdminToken = Utils.generateTestToken(travelAdminPayload);
+const requesterToken = Utils.generateTestToken(requesterPayload);
+
+describe('Update maintenance record', () => {
+  beforeAll(async (done) => {
+    await models.Bed.destroy({ truncate: true, cascade: true });
+    await models.Room.destroy({ truncate: true, cascade: true });
+    await models.GuestHouse.destroy({ truncate: true, cascade: true });
+    await models.User.destroy({ truncate: true, cascade: true });
+    await models.Role.destroy({ truncate: true, cascade: true });
+    await models.UserRole.destroy({ truncate: true, cascade: true });
+
+    await models.Role.bulkCreate(role);
+    await models.User.bulkCreate(userMock);
+    await models.UserRole.bulkCreate(userRoleMock);
+    await models.GuestHouse.create({ ...GuestHouseEpic, userId: '-MUnaemKrxA90lPNQs1FOLNm' });
+    await models.Room.create(GuestHouseEpicRoom);
+    await models.Room.create(GuestHouseEpicRoom2);
+    await models.Bed.bulkCreate(GuestHouseEpicBed);
+    await models.Maintainance.create({ ...maintainanceRecord, roomId: 'bEu6thdW' });
+
+    request(app)
+      .post('/api/v1/room/bEu6thdW/maintainance')
+      .set('authorization', travelAdminToken)
+      .send(maintainanceRecord)
+      .expect(201)
+      .end((err, res) => {
+        expect(res.body.success).toEqual(true);
+        expect(res.body.message).toBe('Room maintainance record created');
+        if (err) return done(err);
+        done();
+      });
+  });
+
+  afterAll(async () => {
+    await models.Role.destroy({ force: true, truncate: { cascade: true } });
+    await models.User.destroy({ force: true, truncate: { cascade: true } });
+    await models.UserRole.destroy({ force: true, truncate: { cascade: true } });
+    await models.Bed.destroy({ truncate: true, cascade: true });
+    await models.Room.destroy({ truncate: true, cascade: true });
+    await models.GuestHouse.destroy({ truncate: true, cascade: true });
+    await models.Maintainance.destroy({ truncate: true, cascade: true });
+  });
+
+  it('should return an error if room doesn\'t exist', (done) => {
+    request(app)
+      .put('/api/v1/room/doesntExist/maintainance')
+      .set('authorization', travelAdminToken)
+      .send(maintainanceRecord)
+      .expect(404)
+      .end((err, res) => {
+        expect(res.body.message).toBe('The room does not exist');
+        if (err) return err;
+        done();
+      });
+  });
+
+  it('should return an error if record doesnt exist', (done) => {
+    request(app)
+      .put('/api/v1/room/cYu7hypT/maintainance')
+      .set('authorization', travelAdminToken)
+      .send(maintainanceRecord)
+      .expect(404)
+      .end((err, res) => {
+        expect(res.body.message).toBe('The maintenance record does not exist');
+        if (err) return err;
+        done();
+      });
+  });
+
+  it('should update successfully if room exist and user is travel admin', (done) => {
+    request(app)
+      .put('/api/v1/room/bEu6thdW/maintainance')
+      .set('authorization', travelAdminToken)
+      .send(updateMaintainanceRecord)
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.message).toBe('Room maintenance record updated');
+        if (err) return err;
+        done();
+      });
+  });
+
+  it('should throw 403 error if room exist and user is not a travel admin', (done) => {
+    request(app)
+      .put('/api/v1/room/bEu6thdW/maintainance')
+      .set('authorization', requesterToken)
+      .send(updateMaintainanceRecord)
+      .expect(403)
+      .end((err, res) => {
+        expect(res.body.success).toEqual(false);
+        expect(res.body.error)
+          .toBe('You don\'t have access to perform this action');
+        if (err) return err;
+        done();
+      });
+  });
+});

--- a/src/modules/guestHouse/index.js
+++ b/src/modules/guestHouse/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import GuestHouseController from './GuestHouseController';
 import middlewares from '../../middlewares';
+import GuestHouseValidator from '../../middlewares/guestHouseValidator';
 
 
 const { authenticate, Validator, RoleValidator } = middlewares;
@@ -69,7 +70,31 @@ Router.post(
     ['Super Administrator', 'Travel Administrator']
   ),
   Validator.validateMaintainanceRecord,
+  GuestHouseValidator.checkRoom,
   GuestHouseController.createMaintainanceRecord,
+);
+
+Router.put(
+  '/room/:id/maintainance',
+  authenticate,
+  RoleValidator.checkUserRole(
+    ['Super Administrator', 'Travel Administrator']
+  ),
+  Validator.validateMaintainanceRecord,
+  GuestHouseValidator.checkRoom,
+  GuestHouseValidator.checkMaintenanceRecord,
+  GuestHouseController.updateMaintenanceRecord
+);
+
+Router.delete(
+  '/room/:id/maintainance',
+  authenticate,
+  RoleValidator.checkUserRole(
+    ['Super Administrator', 'Travel Administrator']
+  ),
+  GuestHouseValidator.checkRoom,
+  GuestHouseValidator.checkMaintenanceRecord,
+  GuestHouseController.deleteMaintenanceRecord
 );
 
 export default Router;


### PR DESCRIPTION
#### What does this PR do?
- This PR enables a travel admin to update or delete maintenance records.

#### Description of Task to be completed?
- A travel admin should be able to delete maintenance records.
- A travel admin should be able to update maintenance records.

#### How should this be manually tested?
- Clone the repository and enter the project's folder
- Checkout to `ft-restore-or-delete-room-maintenance-162152454`
- Assign yourself the travel admin role by changing your roleId to 29187 in the users table
- Start the application using 'make start'
- Open postman and provide your token in the authorization header.
- If you do not have a guest house id, see [this](https://github.com/andela/travel_tool_back/pull/65) for guesthouse structure to create one
- Make a `POST` request to `/api/v1/room/:room-id/maintainance`. Ensure to add the `id` as the ID of any room.
- Then make a `PUT` request to the same route while changing the request body.
- Then make a `DELETE` request to the same route.
`THE BODY STRUCTURE`
```
{
	"reason":"Broken windows",
	"start":"10/28/2018",
	"end":"2018-10-16"
}
```

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162152454](https://www.pivotaltracker.com/story/show/162152454)

#### Screenshots (if appropriate)
<img width="1440" alt="screenshot 2018-11-23 at 15 31 50" src="https://user-images.githubusercontent.com/12511966/48943681-f9051d80-ef34-11e8-9bc4-cf0ca3910dbe.png">
<img width="1440" alt="screenshot 2018-11-23 at 15 32 07" src="https://user-images.githubusercontent.com/12511966/48943682-f99db400-ef34-11e8-8d59-478529c3dbdb.png">

#### Questions:
N/A
