### PR TITLE
#162232273 Allow travel team members to view dashboard

### DIFF
--- a/src/modules/analytics/index.js
+++ b/src/modules/analytics/index.js
@@ -16,14 +16,17 @@ Router.get(
   '/analytics/trips/departments',
   authenticate,
   RoleValidator.checkUserRole(
-    ['Super Administrator', 'Travel Administrator']
+    ['Super Administrator', 'Travel Administrator', 'Travel Team Member']
   ),
   analyticsValidator.validateFilterAndType,
   TripsController.getTripsPerMonth,
 );
 
 Router.get('/analytics',
-  authenticate, RoleValidator.checkUserRole(['Super Administrator', 'Travel Administrator']),
+  authenticate,
+  RoleValidator.checkUserRole(
+    ['Super Administrator', 'Travel Administrator', 'Travel Team Member']
+  ),
   AnalyticsController.analytics);
 
 Router.get(
@@ -32,7 +35,7 @@ Router.get(
   travelReadinessValidators,
   Validator.validateRequest,
   RoleValidator.checkUserRole(
-    ['Super Administrator', 'Travel Administrator']
+    ['Super Administrator', 'Travel Administrator', 'Travel Team Member']
   ),
   ReadinessController.getReadinessCsv
 );
@@ -40,7 +43,7 @@ Router.get(
 Router.get('/analytics/calendar',
   authenticate,
   RoleValidator.checkUserRole(
-    ['Super Administrator', 'Travel Administrator']
+    ['Super Administrator', 'Travel Administrator', 'Travel Team Member']
   ),
   travelCalendarValidator.validateRequestQuery,
   CalendarController.getTravelCalendarAnalytics);


### PR DESCRIPTION
#### What does this PR do?
Allows Users with the role 'Travel Team Member' to access the the analytics routes.

#### Description of Task to be completed?
- add 'Travel Team Member' to included permissions to perform actions
  on the analytics route

#### How should this be manually tested?
1. Clone the repo
    `git clone https://github.com/andela/travel_tool_back.git`
 2. Switch to the project directory
   `cd travel_tool_back`
 3. Checkout the **ch-travel-team-views-dashboard-16223227** branch
   `git checkout ch-travel-team-views-dashboard-16223227`
 4. Rollback, run database migrations and seed database
   `yarn db:rollmigrate`
 5. Start the [frontend](https://github.com/andela/travel_tool_front/pull/357) of the application.
 6. Login with your andela account then change your role in the UserRoles table to **339458** (Travel Team Member).
 7. Copy your jwt from the cookies in the browser and paste it to postman Authorization.
 8. Make a GET request to the following endpoints:
    * `api/v1/analytics/trips/departments`
    * `api/v1/analytics`
    * `api/v1analytics/readiness`
    * `api/v1/analytics/calendar`

For all the above endpoints, you should not receive a 403 error. A travel team member should be allowed to access these endpoints.

#### Any background context you want to provide?
You will need the frontend PR ([#357](https://github.com/andela/travel_tool_front/pull/357)) to view the dashboard on the browser.

#### What are the relevant pivotal tracker stories?
* [#162232273](https://www.pivotaltracker.com/story/show/162232273)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A