### PR TITLE
#162181636 Enforce proper checkin by users in guest house rooms

### DIFF
--- a/src/modules/trips/TripsController.js
+++ b/src/modules/trips/TripsController.js
@@ -108,6 +108,14 @@ class TripsController {
           message: checkTypeErrorMessage
         });
       }
+      const checkInDate = returnedTrip.departureDate;
+      const dateToday = (new Date().toISOString()).slice(0, 10);
+      if (dateToday < checkInDate) {
+        return res.status(400).json({
+          success: false,
+          message: `Please try checking in on ${new Date(checkInDate).toDateString()}`
+        });
+      }
       const updatedTrip = await TripsController
         .updateTrip(returnedTrip, checkType);
       TripsController.sendNotification(req, updatedTrip.request, checkType);

--- a/src/modules/trips/__tests__/TripsController.test.js
+++ b/src/modules/trips/__tests__/TripsController.test.js
@@ -262,6 +262,19 @@ describe('Test Suite for Trips Controller', () => {
           });
       });
 
+      it('should not update trip record to check in before due date', (done) => {
+        request(app)
+          .put('/api/v1/trips/5')
+          .set('Content-Type', 'application/json')
+          .set('authorization', token)
+          .send(checkInData)
+          .end((err, res) => {
+            expect(res.body.success).toEqual(false);
+            if (err) return done(err);
+            done();
+          });
+      });
+
       it('should update trip record to check in', (done) => {
         request(app)
           .put('/api/v1/trips/2')
@@ -354,7 +367,7 @@ describe('Test Suite for Trips Controller', () => {
           .end((err, res) => {
             expect(res.statusCode).toEqual(200);
             expect(res.body.success).toEqual(true);
-            expect(res.body.trips.length).toEqual(3);
+            expect(res.body.trips.length).toEqual(4);
             expect(res.body.message).toEqual('Retrieved Successfully');
             if (err) return done(err);
             done();

--- a/src/modules/trips/__tests__/mocks/tripData.js
+++ b/src/modules/trips/__tests__/mocks/tripData.js
@@ -1,4 +1,6 @@
 const date = new Date();
+const dateToday = new Date(date.setDate(date.getDate()))
+  .toISOString().split('T')[0];
 const dateDeparture = new Date(date.setDate(date.getDate() + 1))
   .toISOString().split('T')[0];
 const dateReturn = new Date(date.setDate(date.getDate() + 3))
@@ -7,6 +9,7 @@ const dateReturn = new Date(date.setDate(date.getDate() + 3))
 export const dates = {
   departureDate: dateDeparture,
   returnDate: dateReturn,
+  dateToday
 };
 
 export const checkInData = {
@@ -84,7 +87,7 @@ export const tripsData = [
     origin: 'New York',
     destination: 'Nairobi',
     bedId: 1,
-    departureDate: dates.departureDate,
+    departureDate: dates.dateToday,
     returnDate: dates.returnDate,
   },
   {
@@ -106,7 +109,16 @@ export const tripsData = [
     returnDate: dates.returnDate,
     checkOutDate: dates.returnDate,
     checkStatus: 'Checked Out'
-  }
+  },
+  {
+    id: 5,
+    requestId: 'xDh20cuGy',
+    origin: 'New York',
+    destination: 'Nairobi',
+    bedId: 1,
+    departureDate: dates.departureDate,
+    returnDate: dates.returnDate,
+  },
 ];
 
 export const tripsResponse = {


### PR DESCRIPTION
#### What does this PR do?
 - add backup support for the frontend to ensure that a user should only be able to check-in when it is their arrival date.

#### Description of Task to be completed?
- A user should only be able to check-in when it is their arrival date
  - I should only be able to **check-in** to a guest house when my **arrival date** is **due**
so that I do not deprive other users of using a guest house before I arrive.

#### How should this be manually tested?
- Setting up the backend
     - Clone the repo - `git clone https://github.com/andela/travel_tool_back.git`
     - Enter into the project directory - `cd travel_tool_back`
     - checkout the branch git checkout `ft-enforce-proper-checkin-162181636`
     - Install dependencies using `yarn install`
     - Rollback and run database migrations with `yarn db:rollmigrate`
     - When making a put request for checking in use this as the request body
```
{
	"checkType":"checkIn"
}
```
- Setting up the frontend
   - Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`.
   - Enter into the project directory - `cd travel_tool_front`.
   - Checkout to the branch `ft-enforce-proper-checkin-162181636` then run the app
   - Login to the application
   - Navigate to the requests page as a travel manager and create a new travel request
      -  ensure to select a future date for proper testing.
   - As a manager user approve your travel request.

   - Open Postico and find the Id of the newly approved trip

<img width="1268" alt="screen shot 2018-11-28 at 08 39 22" src="https://user-images.githubusercontent.com/21138053/49131447-40026280-f2e9-11e8-98b8-1d7c49fa435f.png">

   - Open Postman and make a put request to this endpoint `http://127.0.0.1:5000/api/v1/trips/<tripId>`
   ```
{
	"checkType":"checkIn"
}
```
   - If the date of check-in is not today then you should get a response similar to this

```
{
    "success": false,
    "message": "Please try checking in on Sat Dec 01 2018"
}
```
#### Any background context you want to provide?
- To ensure that the user never checks in before the due date, I compared the check-in date with today date and if both match then updates the records in the database.
- This enhancement to the functionality ensures proper check-in enforcement for users who might try to figure out a way to change dates on the front end and enable the check-in button

#### What are the relevant pivotal tracker stories?
[#162181636](https://www.pivotaltracker.com/story/show/162181636)

#### Screenshots (if appropriate)
<img width="1220" alt="screen shot 2018-11-28 at 08 36 23" src="https://user-images.githubusercontent.com/21138053/49131297-bc487600-f2e8-11e8-8db1-41faca481a10.png">
