### PR TITLE
fix(request): no beds found on making requests

### DIFF
--- a/src/modules/guestHouse/RoomsManager.js
+++ b/src/modules/guestHouse/RoomsManager.js
@@ -88,6 +88,7 @@ class RoomsManager {
       attributes: ['bedId'],
       where: {
         destination: location,
+        bedId: { [Op.ne]: null },
         [Op.or]: {
           [Op.and]: {
             departureDate: { [Op.lte]: departureDate },
@@ -154,6 +155,7 @@ class RoomsManager {
         attributes: ['bedId'],
         where: {
           destination: location,
+          bedId: { [Op.ne]: null },
           [Op.or]: {
             ...RoomsManager.getDateRange(departureDate, arrivalDate)
           },


### PR DESCRIPTION
#### What does this PR do?
This PR ensures that beds are found when making travel requests in centers with available guest houses

#### Description of Task to be completed?
- update booked beds and opposite gender query to ignore records with null bed ids

#### How should this be manually tested?
- Clone the repo - `git clone https://github.com/andela/travel_tool_back.git`
- Change into the project directory -` cd travel_tool_front`
- Pull and checkout into this branch - `bg-fix-available-rooms-162312737`
- Install project dependencies using `yarn install`
- Clone the [Travela frontend](https://github.com/andela/travel_tool_front)
- Run database migrations using `yarn run db:rollmigrate`
- Check `.env.example` and set up your `.env` appropriately
- Start the Server and Frontend with `make start` and log into the application
- Create a new travel request
- On the new request form, for a multi city trip
  -  Filling the accomadation field should find beds if destination has available beds in its guesthouse

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162312737](https://www.pivotaltracker.com/story/show/162312737)

#### Screenshots (if appropriate)

#### Questions:
N/A
