### PR TITLE
#162305343 Disable and restore guesthouses

### DIFF
--- a/src/database/migrations/20181203102954-guesthouse-add-disabled-column.js
+++ b/src/database/migrations/20181203102954-guesthouse-add-disabled-column.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'GuestHouses', 'disabled',
+    {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    }
+  ),
+  down: queryInterface => queryInterface.removeColumn('GuestHouses', 'disabled')
+};

--- a/src/database/models/guesthouse.js
+++ b/src/database/models/guesthouse.js
@@ -23,6 +23,11 @@ export default (sequelize, DataTypes) => {
         allowNull: false,
         type: DataTypes.STRING
       },
+      disabled: {
+        allowNull: false,
+        type: DataTypes.BOOLEAN,
+        defaultValue: false
+      }
     },
   );
   GuestHouse.associate = (models) => {

--- a/src/modules/guestHouse/RoomsManager.js
+++ b/src/modules/guestHouse/RoomsManager.js
@@ -45,7 +45,8 @@ class RoomsManager {
               as: 'guestHouses',
               model: models.GuestHouse,
               where: {
-                location
+                location,
+                disabled: false
               }
             }
           ]

--- a/src/modules/guestHouse/__tests__/mocks/guestHouseData.js
+++ b/src/modules/guestHouse/__tests__/mocks/guestHouseData.js
@@ -404,3 +404,15 @@ export const editGuestHouseEpicData4 = {
     ],
   }
 };
+
+export const GuestHouseDetails = {
+  id: '89uih9ef',
+  houseName: 'Continental',
+  location: 'Kigali, Rwanda',
+  bathRooms: '3',
+  disabled: false,
+  imageUrl: 'https://www.ihoui0i.com',
+  userId: '-TJN89injbboihi',
+  createdAt: '2018-09-26T15:47:47.576Z',
+  updatedAt: '2018-09-26T15:47:47.576Z',
+};

--- a/src/modules/guestHouse/__tests__/updateGuestHouse.test.js
+++ b/src/modules/guestHouse/__tests__/updateGuestHouse.test.js
@@ -8,6 +8,7 @@ import {
   GuestHouseEpic,
   GuestHouseEpicRoom,
   GuestHouseEpicBed,
+  GuestHouseDetails,
 } from './mocks/guestHouseData';
 
 const payload = {
@@ -130,6 +131,68 @@ describe('Update the room fault status', () => {
             .end((err, res) => {
               expect(res.body.success).toEqual(false);
               expect(res.body.message).toBe('Room status can only be true or false');
+              if (err) return done(err);
+              done();
+            });
+        });
+      });
+
+      describe('Disable and Restore Guesthouse', () => {
+        beforeAll(async () => {
+          await models.GuestHouse.destroy({ truncate: { cascade: true } });
+          await models.GuestHouse.create(GuestHouseDetails);
+        });
+        afterAll(async () => {
+          await models.GuestHouse.destroy({ truncate: { cascade: true } });
+        });
+
+        it('return error if guesthouse does not exist', (done) => {
+          request(app)
+            .put('/api/v1/guesthouse/iijkn')
+            .set('authorization', token)
+            .expect(404)
+            .end((err, res) => {
+              expect(res.body.success).toEqual(false);
+              expect(res.body.message).toBe('This Guest house does not exist');
+              if (err) return done(err);
+              done();
+            });
+        });
+
+        it('should successfully disable a guesthouse', (done) => {
+          request(app)
+            .put('/api/v1/guesthouse/89uih9ef')
+            .set('authorization', token)
+            .expect(201)
+            .end((err, res) => {
+              expect(res.body.success).toEqual(true);
+              expect(res.body.message).toBe('Guest house has been successfully disabled');
+              if (err) return done(err);
+              done();
+            });
+        });
+
+        it('should get a list of disabled guesthouses', (done) => {
+          request(app)
+            .get('/api/v1/disabledguesthouses')
+            .set('authorization', token)
+            .expect(200)
+            .end((err, res) => {
+              expect(res.body.success).toEqual(true);
+              expect(res.body.message).toBe('Disabled guesthouses retrieved successfully');
+              if (err) return done(err);
+              done();
+            });
+        });
+
+        it('should successfully restore a disabled guest house', (done) => {
+          request(app)
+            .put('/api/v1/guesthouse/89uih9ef')
+            .set('authorization', token)
+            .expect(201)
+            .end((err, res) => {
+              expect(res.body.success).toEqual(true);
+              expect(res.body.message).toBe('Guest house has been successfully restored');
               if (err) return done(err);
               done();
             });

--- a/src/modules/guestHouse/index.js
+++ b/src/modules/guestHouse/index.js
@@ -97,4 +97,22 @@ Router.delete(
   GuestHouseController.deleteMaintenanceRecord
 );
 
+Router.put(
+  '/guesthouse/:id',
+  authenticate,
+  RoleValidator.checkUserRole(
+    ['Super Administrator', 'Travel Administrator']
+  ),
+  GuestHouseController.disableOrRestoreGuesthouse
+);
+
+Router.get(
+  '/disabledguesthouses',
+  authenticate,
+  RoleValidator.checkUserRole(
+    ['Super Administrator', 'Travel Administrator']
+  ),
+  GuestHouseController.getDisabledGuestHouses
+);
+
 export default Router;


### PR DESCRIPTION
#### What does this PR do?
Gives ```Travel Admin``` the ability to disable and restore guesthouses.

#### Description of Task to be completed?
* Add a 'disabled' column to the GuestHouse table, which should be false by default
* Create a method and endpoint for disabling and restoring guesthouses.
* Prevent details of disabled guesthouses from being displayed or edited.
* Prevent rooms in disabled guesthouses from being available in new requests.
* Include tests for newly defined methods.

#### How should this be manually tested?
* Clone the repo with ``` git clone https://github.com/andela/travel_tool_back.git ```
* cd to travel_tool_back
* Checkout to the branch ``` ft-disable-and-restore-guest-houses-162305343 ```
* Run `` yarn ``` to install dependencies
* Run database migrations and seed database with ```yarn db:rollmigrate```
* Start up the server with ``` yarn start:dev ```
* Make a PUT request with the endpoint ``` http://localhost:5000/api/v1/guesthouse/<id>```
* Guest house should be disabled.
* You can also make a GET request with ```http://localhost:5000/api/v1/disabledguesthouses``` to get disabled guesthouses
* Making a next PUT request with the same endpoint, on the same guest house restores it.

#### Any background context you want to provide?
* You should be logged in as a ``` Travel Administrator ``` to perform this action.

#### What are the relevant pivotal tracker stories?
[162305343](https://www.pivotaltracker.com/story/show/162305343)

#### Screenshots (if appropriate)
<img width="1170" alt="screen shot 2018-12-03 at 10 24 20 pm" src="https://user-images.githubusercontent.com/29521319/49402556-7a855880-f74a-11e8-98b6-117adc9f7361.png">


#### Questions:
