### PR TITLE
#162421358 Fix manager change on request approval bug

### DIFF
--- a/src/modules/requests/RequestsController.js
+++ b/src/modules/requests/RequestsController.js
@@ -371,6 +371,19 @@ class RequestsController {
         delete requestDetails.status; // status cannot be updated by requester
         const updatedRequest = await request.updateAttributes(requestDetails);
         const message = 'edited a travel request';
+
+        const requestToApprove = await models.Approval.findOne({
+          where: {
+            requestId: request.id
+          }
+        });
+        if (!requestToApprove) {
+          const error = 'Approval request not found';
+          return Error.handleError(error, 404, res);
+        }
+        await requestToApprove.update({
+          approverId: req.body.manager
+        });
         RequestsController.sendNotificationToManager(
           req,
           res,

--- a/src/modules/requests/__tests__/requests.test.js
+++ b/src/modules/requests/__tests__/requests.test.js
@@ -956,7 +956,6 @@ describe('Requests Controller', () => {
       beforeAll(async (done) => {
         await models.Trip.destroy({ force: true, truncate: { cascade: true } });
         await models.Request.destroy({ force: true, truncate: { cascade: true } });
-
         await models.Request.bulkCreate(
           [mockOpenRequest, mockApprovedRequest, mockRejectedRequest]
         );
@@ -967,6 +966,7 @@ describe('Requests Controller', () => {
             ...mockRejectedRequest.trips
           ]
         );
+        await models.Approval.bulkCreate(allMyApprovals);
         done();
       });
 


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the approvals bug on updating manager on the edit request form

#### Description of Task to be completed?
- On editing the manager for an open request the manager should see the approval on his `Approvals` page

#### How should this be manually tested?
##### Using the browser
* Clone the repos: ``` https://github.com/andela/travel_tool_front ``` and ``` https://github.com/andela/travel_tool_back ```.
* cd into their respective directories ```travel_tool_front``` and ```travel_tool_back```.
* On the frontend checkout `bg-fix-manager-bug-on-edit-162421358` branch.
* On the backend checkout `bg-fix-manager-bug-on-edit-162421358` branch.
* Start the backend by running the `$yarn run start:dev`
* Start the frontend by running `$yarn start`
* Login and create a new request.
* On the newly created request click on the ellipsis and edit it.
* Change the manager and update the request.
* The request should appear on the newly assigned managers `Approvals` page and not the former manager.

##### Using postman
* Clone the repo: https://github.com/andela/travel_tool_back ```.
* cd into the directory ```travel_tool_back```.
* Checkout `bg-fix-manager-bug-on-edit-162421358` branch.
* Start the backend by running the `$yarn run start:dev`
* Navigate to [travela](http://travela-staging.andela.com/) in your browser and login
* Open the developer tools, locate applications tab, copy `jwt-token` in the cookies
* Check `.env.example` and set up your `.env` appropriately
* Get back to your command line, Install dependencies and start the server - `make start`
* In`Postman`, use the `jwt-token` to send a request by adding a `Header`, key `Authorization` and value the `token`.
* In Postman, enter the necessary data in the `x-www-form-urlencoded` options.
* You should be able to post a new request on `localhost:5000/api/v1/requests`
* Get the newly created request id from the database request table.
* You should be able to put an updated request on `localhost:5000/api/v1/requests/:requestId`
* The approvals table should reflect the change in the manager.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162421358](https://www.pivotaltracker.com/story/show/162421358)

#### Screenshots (if appropriate)


#### Questions: