### PR TITLE
#162573849 Allow one way trips with a default return date

### DIFF
--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -59,9 +59,6 @@ export const editAndCreateRequestValidators = [
           .isValid()) {
         throw new Error('Please specify a valid ISO return date');
       }
-      if (req.body.tripType === 'oneWay' && value) {
-        throw new Error('A oneWay trip cannot have a returnDate');
-      }
       return true;
     }),
   body('trips.*.bedId', 'bed id is an integer and optional').optional(),

--- a/src/modules/requests/__tests__/requests.test.js
+++ b/src/modules/requests/__tests__/requests.test.js
@@ -1018,20 +1018,49 @@ describe('Requests Controller', () => {
           });
       });
 
-      it('should return 422 error if a user tries to update a oneWay request with a returnDate',
+      it('should return 409 error if the request has been approved or rejected', (done) => {
+        const expectedResponse = {
+          body: {
+            success: false,
+            error: 'Request could not be updated because it has been approved',
+          },
+          status: 409,
+        };
+        request(app)
+          .put(`/api/v1/requests/${mockApprovedRequest.id}`)
+          .set('authorization', requesterToken)
+          .send(updateDetails)
+          .end((err, res) => {
+            expect(res).toMatchObject(expectedResponse);
+            done();
+          });
+      });
+
+      it('should return 404 error if the request does not exist', (done) => {
+        const expectedResponse = {
+          body: {
+            success: false,
+            error: 'Request was not found',
+          },
+          status: 404,
+        };
+        request(app)
+          .put('/api/v1/requests/abcdef')
+          .set('authorization', requesterToken)
+          .send(updateDetails)
+          .end((err, res) => {
+            expect(res).toMatchObject(expectedResponse);
+            done();
+          });
+      });
+
+      it('should return 200 if a user tries to update a oneWay request with a returnDate',
         (done) => {
           const expectedResponse = {
             body: {
-              success: false,
-              errors: [
-                {
-                  location: 'body',
-                  param: 'trips[0].returnDate',
-                  msg: 'A oneWay trip cannot have a returnDate',
-                },
-              ],
+              success: true,
             },
-            status: 422,
+            status: 200,
           };
           request(app)
             .put(`/api/v1/requests/${mockOpenRequest.id}`)
@@ -1080,42 +1109,6 @@ describe('Requests Controller', () => {
               }
             ]
           })
-          .end((err, res) => {
-            expect(res).toMatchObject(expectedResponse);
-            done();
-          });
-      });
-
-      it('should return 409 error if the request has been approved or rejected', (done) => {
-        const expectedResponse = {
-          body: {
-            success: false,
-            error: 'Request could not be updated because it has been approved',
-          },
-          status: 409,
-        };
-        request(app)
-          .put(`/api/v1/requests/${mockApprovedRequest.id}`)
-          .set('authorization', requesterToken)
-          .send(updateDetails)
-          .end((err, res) => {
-            expect(res).toMatchObject(expectedResponse);
-            done();
-          });
-      });
-
-      it('should return 404 error if the request does not exist', (done) => {
-        const expectedResponse = {
-          body: {
-            success: false,
-            error: 'Request was not found',
-          },
-          status: 404,
-        };
-        request(app)
-          .put('/api/v1/requests/abcdef')
-          .set('authorization', requesterToken)
-          .send(updateDetails)
           .end((err, res) => {
             expect(res).toMatchObject(expectedResponse);
             done();


### PR DESCRIPTION
#### What does this PR do?
Allows one-way trips to be created with a default return date of one month after departure

#### Description of Task to be completed?
Currently, a one-way trip cannot be created with a return date.
This PR adds functionality to allow a one way trip to be created with a default return date of one month after the departure date.

#### How should this be manually tested?
##### Backend
- Using your terminal, clone this repo -``` git clone https://github.com/andela/travel_tool_back.git```
- Change directory to the repo in your text editor-```cd travela_tool_back```
- Open the project in your text editor
- Checkout to this branch-```ft-one-way-trip-return-date-162573849```
- Run ```yarn install``` on your terminal
- Run ```yarn db:rollmigrate```
- Run `yarn run start:dev` or `make start` (if you use docker) to start the backend server.
- Run tests using `make test`

##### Frontend
- Clone the repo
    `git clone https://github.com/andela/travel_tool_front.git`
 - Switch to the project directory
   `cd travel_tool_front`
 - Checkout the **ft-one-way-trip-accommodation-162573849** branch
   `git checkout ft-one-way-trip-accommodation-162573849`
 - Install dependencies and start the server
   - `make start` *if you have docker*
   - `yarn install` then `yarn start` *if you do not have docker*
 - Navigate to [travela](http://travela-local.andela.com:3000/) in your browser and log in with your Andela account. 
 - Click on `New Request` and select `One Way Trip`.
 - Fill in the form and submit.

#### Any background context you want to provide?
One way trips now have a return date of one month by default

#### What are the relevant pivotal tracker stories?
[#162573849](https://www.pivotaltracker.com/n/projects/2184887/stories/162573849)

#### Screenshots (if appropriate)
<img width="1105" alt="one way trip accommodation option" src="https://user-images.githubusercontent.com/38077368/49997523-d8177180-ffa2-11e8-8f0a-f5e0b7fade8d.png">


#### Questions:
N/A
