### PR TITLE
#162696526 Seed approvals and user without explicitly setting an id

### DIFF
--- a/src/database/seeders/e2e/20180927152303-create-user.js
+++ b/src/database/seeders/e2e/20180927152303-create-user.js
@@ -5,7 +5,6 @@ module.exports = {
     'Users',
     [
       {
-        id: 1,
         fullName: 'Travela Test',
         email: 'travela-test@andela.com',
         userId: '-LSsFyueC086niFc9rrz',
@@ -20,7 +19,6 @@ module.exports = {
         picture: 'https://lh5.googleusercontent.com/-PbuF53uxx4U/AAAAAAAAAAI/AAAAAAAAAAA/AGDgw-i0-XeoeYYk7TpfNBvulhV0oFM6eg/mo/photo.jpg?sz=50'
       },
       {
-        id: 2,
         fullName: 'John Doe',
         email: 'john.doe@andela.com',
         userId: '-LMgZQKq6MXAj_41iRWi',

--- a/src/database/seeders/e2e/20181213073028-e2e-approved-request.js
+++ b/src/database/seeders/e2e/20181213073028-e2e-approved-request.js
@@ -2,7 +2,6 @@ module.exports = {
   up: queryInterface => queryInterface.bulkInsert('Approvals',
     [
       {
-        id: '1',
         requestId: '3451',
         status: 'Approved',
         approverId: 'Travela Test',
@@ -11,7 +10,6 @@ module.exports = {
         deletedAt: null
       },
       {
-        id: '2',
         requestId: '3459',
         status: 'Open',
         approverId: 'Travela Test',
@@ -20,7 +18,6 @@ module.exports = {
         deletedAt: null
       },
       {
-        id: '3',
         requestId: '3458',
         status: 'Open',
         approverId: 'Travela Test',
@@ -29,7 +26,6 @@ module.exports = {
         deletedAt: null
       },
       {
-        id: '4',
         requestId: '34510',
         status: 'Open',
         approverId: 'Travela Test',
@@ -38,7 +34,6 @@ module.exports = {
         deletedAt: null
       },
       {
-        id: '5',
         requestId: '3452',
         status: 'Rejected',
         approverId: 'Travela Test',


### PR DESCRIPTION
#### What does this PR do?
- Add approvals and users without explicitly setting IDs.

#### Description of Task to be completed?
- Add approvals and users without explicitly setting IDs. Let postgres sequentially provide the ids.

#### How should this be manually tested?
- Clone the repo
    `git clone https://github.com/andela/travel_tool_front.git`
 - Switch to the project directory
   `cd travel_tool_front`
 - Checkout the **ch-seed-approvals-and-users-without-IDs-162696526** branch
   `git checkout ch-seed-approvals-and-users-without-IDs-162696526`
- Run:
  `yarn db:rollback && yarn db:migrate && yarn db:seed:e2e`
- Take a look at your database, There should be five approvals and two users with sequential IDs.
- Start the backend:
  `yarn start:dev`
- Run the [frontend](https://GitHub.com/andela/travel_tool_front/pull/407) tests.

#### Any background context you want to provide?
This branch will be needed to run the end to end tests on [this](https://github.com/andela/travel_tool_front/pull/407) PR

#### What are the relevant pivotal tracker stories?
* [#162696526](https://www.pivotaltracker.com/story/show/162696526)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/41262970/50080733-d5fd1f00-01fd-11e9-9f43-905796c278fa.png)
![image](https://user-images.githubusercontent.com/41262970/50080736-d7c6e280-01fd-11e9-86af-ef2455e5b3f2.png)
#### Questions:
N/A